### PR TITLE
fix: 0+Enter 일시정지 토글이 키 auto-repeat로 인해 즉시 재토글되어 복귀되지 않던 버그 수정

### DIFF
--- a/HanSon/CheonJiInKeyHandler.cs
+++ b/HanSon/CheonJiInKeyHandler.cs
@@ -20,7 +20,7 @@ namespace HanSon
         private int _langMode = 0;       // 0: Korean, 1: English
         private bool _isActive = true;
         private char _engBuf = ' ', _symBuf = ' ';
-        private bool _isZeroDown, _isEnterDown;
+        private bool _isZeroDown, _isEnterDown, _toggleLatched;
 
         private struct KeyDef
         {
@@ -69,13 +69,18 @@ namespace HanSon
                 case Keys.Enter:    _isEnterDown = true; Reset(); break;
             }
 
-            if (_isZeroDown && _isEnterDown) ToggleActive(ref e);
+            if (_isZeroDown && _isEnterDown && !_toggleLatched)
+            {
+                _toggleLatched = true;
+                ToggleActive(ref e);
+            }
         }
 
         public void KeyUp(ref KeyEventArgs e)
         {
             if (e.KeyCode == Keys.NumPad0) _isZeroDown = false;
             else if (e.KeyCode == Keys.Enter) _isEnterDown = false;
+            if (!_isZeroDown && !_isEnterDown) _toggleLatched = false;
         }
 
         private void Cycle(string chars, ref char buf)


### PR DESCRIPTION
Windows의 키 auto-repeat 에 대한 내용

1번. 0+Enter를 누르고 있는 동안 KeyDown 이벤트가 반복 발생하면 ToggleActive가 짝수번 호출되어 사용자가 보기에는 토글이
"동작하지 않는" 것처럼 보였음. -> 다시 눌러도 돌아오지 않음.

2번. _toggleLatched 플래그를 도입하여 한 번 토글된 후에는 두 키가 모두
KeyUp 될 때까지 재토글을 잠그도록 수정.